### PR TITLE
cats ears

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -13,9 +13,11 @@
 
 - type: marking
   id: CatEars
+  # Arcane-start
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [Human, Dwarf, Demon, Felinid]
+  # Arcane-end
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -13,8 +13,8 @@
 
 - type: marking
   id: CatEars
-  bodyPart: Special
-  markingCategory: Special
+  bodyPart: HeadTop
+  markingCategory: HeadTop
   speciesRestriction: [Human, Dwarf, Demon, Felinid]
   coloring:
     default:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -15,7 +15,7 @@
   id: CatEars
   bodyPart: Special
   markingCategory: Special
-  speciesRestriction: []
+  speciesRestriction: [Human, Dwarf, Demon, Felinid]
   coloring:
     default:
       type:


### PR DESCRIPTION
кошачьи ушки для гуманойдов

<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
<!-- Опишите здесь ваш Pull Request (PR). Что он изменяет? На что еще это может повлиять? -->

## Медиа
<!-- Добавьте скриншоты/видео, для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте скриншоты, иначе он может быть закрыт. -->

## Тип PR
<!-- Подходите ответственно к пометке этих пунктов, для этого необходимо поставить английскую "x" между квадратных скобок -->

- [x] Feature
- [ ] Fix
- [ ] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят

Вы можете поставить свой ник после символа :cl:, чтобы изменить ник, который будет отображаться в журнале изменений (в противном случае будет использоваться ник вашего аккаунта GitHub)
Например: ":cl: Vecortys".

Как правило, в журналы изменений следует помещать только то, что действительно важно игрокам. Вещи вроде "Рефактор системы X, но изменений вы не увидите" - не должны быть в журнале изменений, эти изменения обычные игроки не смогут заметить.

При написании списка изменений НЕ считайте суффикс типа записи (например, add) "частью" предложения:
Плохо: - add: Хирургия может вырезать яйца.
Хорошо: - add: Добавлена хирургическая операция, которая позволяет вырезать яйца.
-->

<!-- Не забудьте убрать стрелки, что-бы changelog отображался, если вы считаете, что он нужен.
:cl:
- add: Добавлено веселье.
- remove: Убрано веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Маркировка кошачьих ушей перемещена в категорию верхней части головы; теперь доступна лишь для рас: Человек, Дварф, Демон и Фелинид.
  * Отформатированы данные спрайта кошачьего хвоста — изменения затронули только представление данных, визуально для пользователя ничего не изменилось.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcaneSS14/arcane-station/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->