### PR TITLE
Лицехваты больше не заражают ксеноморфов

### DIFF
--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/facehugger.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/facehugger.yml
@@ -60,6 +60,8 @@
       - Ghost
       - XenomorphEgg
       - FacehuggerImmune # Goobstation
+      tags:
+      - HumanoidXeno # Arcane
     damageOnImpact:
       types:
         Blunt: 15


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
Занёс ксеноморфов в чёрный список лицехватов. Теперь они не могут иъ заразить.
По лору лицехваты не могут заражать других ксеноморфов. Им нужны именно другие существа, чтобы эмбрион перенял их генетический материал и сожрал изнутри, для чего сородичи не годятся. Дикие особи по отношению к представителям из других ульев часто агрессивны, но они не заражают их, они просто их убивают. 
## Медиа
<!-- Добавьте скриншоты/видео, для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте скриншоты, иначе он может быть закрыт. -->

## Тип PR
<!-- Подходите ответственно к пометке этих пунктов, для этого необходимо поставить английскую "x" между квадратных скобок -->

- [ ] Feature
- [ ] Fix
- [x] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

**Изменения**
:cl: seemah
- tweak: Теперь ксеноморфы не могут быть заражены лицехватом.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Чоры**
  * Обновлены зависимости фреймворка до последней версии.

* **Изменения игровой механики**
  * Добавлена классификационная метка для мобов типа Facehugger.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArcaneSS14/arcane-station/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->