### PR TITLE
Ксено больше не усваивают газы

### DIFF
--- a/Resources/Prototypes/_Arcane/Body/Organs/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Arcane/Body/Organs/humanoid_xeno.yml
@@ -69,7 +69,7 @@
 
 - type: entity
   id: OrganHumanoidXenoLungs
-  parent: [BaseHumanoidXenoOrgan, OrganHumanLungs]
+  parent: [BaseHumanoidXenoOrgan]
   name: lungs
   description: They filter oxygen from the atmosphere and channel it into the bloodstream, where it is used as an electron carrier.
   components:
@@ -77,17 +77,12 @@
     layers:
       - state: lung-l
       - state: lung-r
-  - type: Lung
-  - type: Metabolizer
   - type: SolutionContainerManager
     solutions:
       organ:
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
-      Lung:
-        maxVol: 100.0
-        canReact: false
       food:
         maxVol: 5
         reagents:


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
Они не дышат. Так что теперь они не могут отравиться и не могут упороться всяким атмосианским пердежом.
## Медиа
<!-- Добавьте скриншоты/видео, для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте скриншоты, иначе он может быть закрыт. -->

## Тип PR
<!-- Подходите ответственно к пометке этих пунктов, для этого необходимо поставить английскую "x" между квадратных скобок -->

- [ ] Feature
- [ ] Fix
- [x] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

:cl: seemah
- tweak: Ксеноморфы больше не усваивают газы.