### PR TITLE
Expand service borg module capabilities

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1002,11 +1002,13 @@
   - type: ItemBorgModule
     moduleId: Service
     items:
+    # - Pen # Arcane-Edit: Moved
     #- BooksBag (Add back when hand whitelisting exists, at the moment they can only use it like an orebag.)
     - HandLabeler
-    - Lighter
+    - Lighter # Arcane
     - RubberStampApproved
     - RubberStampDenied
+    # - Lighter # Arcane-Edit: Moved
     # Frontier: droppable borg items
     # - DrinkShaker
     # - BorgDropper
@@ -1018,7 +1020,7 @@
         components:
         - FitsInDispenser
     # End Frontier: droppable borg items
-    # Arcane-Edit-Start
+    # Arcane-Start
         tags:
         - DrinkBottle
         - Beer
@@ -1047,7 +1049,7 @@
         - Figurine
         - TabletopBoard
         - Write
-    # Arcane-Edit-End
+    # Arcane-End
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: service-module }
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1002,13 +1002,13 @@
   - type: ItemBorgModule
     moduleId: Service
     items:
-    # - Pen # Arcane-Edit: Moved
+#    - Pen # Arcane-Edit: Moved
     #- BooksBag (Add back when hand whitelisting exists, at the moment they can only use it like an orebag.)
     - HandLabeler
     - Lighter # Arcane
     - RubberStampApproved
     - RubberStampDenied
-    # - Lighter # Arcane-Edit: Moved
+#    - Lighter # Arcane-Edit: Moved
     # Frontier: droppable borg items
     # - DrinkShaker
     # - BorgDropper

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1024,8 +1024,11 @@
         - Beer
     - id: BarSpoon
       whitelist:
+        requireAll: true
+        components:
+        - ReactionMixer
         tags:
-        - BarSpoon
+        - Metal
     - id: Pen
       whitelist:
         tags:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1002,12 +1002,11 @@
   - type: ItemBorgModule
     moduleId: Service
     items:
-    - Pen
     #- BooksBag (Add back when hand whitelisting exists, at the moment they can only use it like an orebag.)
     - HandLabeler
+    - Lighter
     - RubberStampApproved
     - RubberStampDenied
-    - Lighter
     # Frontier: droppable borg items
     # - DrinkShaker
     # - BorgDropper
@@ -1019,6 +1018,33 @@
         components:
         - FitsInDispenser
     # End Frontier: droppable borg items
+    # Arcane-Edit-Start
+        tags:
+        - DrinkBottle
+        - Beer
+    - id: BarSpoon
+      whitelist:
+        tags:
+        - BarSpoon
+    - id: Pen
+      whitelist:
+        tags:
+        - Book
+        - Dice
+        - Document
+        - Figurine
+        - TabletopBoard
+        - Write
+    - id: Paper
+      whitelist:
+        tags:
+        - Book
+        - Dice
+        - Document
+        - Figurine
+        - TabletopBoard
+        - Write
+    # Arcane-Edit-End
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: service-module }
 


### PR DESCRIPTION
# Описание PR

Расширение возможности сервисного модуля.

Сервисный борг теперь имеет в руках ручку и бумагу, которые может заменить на любой предмет из вайтлиста бюрократических штук, включая мелки.

Также добавлена барная ложка и расширен список в слоте шейкера для поднятия бОльших видов бутылок с алкомата. Теперь можно комфортнее готовить и наливать напитки.

## Медиа

<p align="center">
  <img width="589" alt="image" src="https://github.com/user-attachments/assets/f1b8e549-113f-4b55-abfb-97beafc5c0a2">
</p>

<p align="center">
  <i>Как выглядит в игре</i>
</p>

## Тип PR

- [ ] Feature
- [ ] Fix
- [x] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite
