### PR TITLE
[Feature] Xenomorph buff

### DIFF
--- a/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
+++ b/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
@@ -118,22 +118,29 @@ public sealed partial class GrabIntentSystem : EntitySystem
             return;
 
         var grabStageOverride = args.GrabStageOverride;
+        var isXenoInstant = false;
+        XenoInstantGrabComponent? xenoGrab = null;
 
-        if (TryComp<XenoInstantGrabComponent>(args.Puller, out var xenoGrab))
+        if (TryComp(args.Puller, out xenoGrab) && _timing.CurTime >= xenoGrab.NextInstantGrab)
         {
-            if (_timing.CurTime >= xenoGrab.NextInstantGrab)
-            {
-                grabStageOverride = GrabStage.Hard;
-                xenoGrab.NextInstantGrab = _timing.CurTime + xenoGrab.Cooldown;
-                Dirty(args.Puller, xenoGrab);
-            }
+            grabStageOverride = GrabStage.Hard;
+            isXenoInstant = true;
         }
 
-        args.Grabbed = TryGrab((ent.Owner, pullable, ent.Comp),
+        var grabbed = TryGrab((ent.Owner, pullable, ent.Comp),
             args.Puller,
             args.IgnoreCombatMode,
             grabStageOverride,
             args.EscapeAttemptModifier);
+
+        args.Grabbed = grabbed;
+
+        // Кулдаун срабатывает только если TryGrab вернул true
+        if (grabbed && isXenoInstant && xenoGrab != null)
+        {
+            xenoGrab.NextInstantGrab = _timing.CurTime + xenoGrab.Cooldown;
+            Dirty(args.Puller, xenoGrab);
+        }
     } // Arcane
 
     private void OnPullableMoveInput(EntityUid uid, GrabbableComponent component, ref MoveInputEvent args)

--- a/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
+++ b/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using Content.Goobstation.Common.Grab;
+using Content.Goobstation.Shared.Xenomorph;
 using Content.Shared._EinsteinEngines.Contests;
 using Content.Shared._White.Grab;
 using Content.Shared.ActionBlocker;
@@ -111,17 +112,29 @@ public sealed partial class GrabIntentSystem : EntitySystem
         args.IsGrabbed = component.GrabStage != GrabStage.No;
     }
 
-    private void OnGrabAttempt(Entity<GrabbableComponent> ent, ref GrabAttemptEvent args)
+    private void OnGrabAttempt(Entity<GrabbableComponent> ent, ref GrabAttemptEvent args) // Arcane - хардграб ксеноморфам
     {
         if (!TryComp<PullableComponent>(ent, out var pullable))
             return;
 
+        var grabStageOverride = args.GrabStageOverride;
+
+        if (TryComp<XenoInstantGrabComponent>(args.Puller, out var xenoGrab))
+        {
+            if (_timing.CurTime >= xenoGrab.NextInstantGrab)
+            {
+                grabStageOverride = GrabStage.Hard;
+                xenoGrab.NextInstantGrab = _timing.CurTime + xenoGrab.Cooldown;
+                Dirty(args.Puller, xenoGrab);
+            }
+        }
+
         args.Grabbed = TryGrab((ent.Owner, pullable, ent.Comp),
             args.Puller,
             args.IgnoreCombatMode,
-            args.GrabStageOverride,
+            grabStageOverride,
             args.EscapeAttemptModifier);
-    }
+    } // Arcane
 
     private void OnPullableMoveInput(EntityUid uid, GrabbableComponent component, ref MoveInputEvent args)
     {

--- a/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
+++ b/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
@@ -112,36 +112,49 @@ public sealed partial class GrabIntentSystem : EntitySystem
         args.IsGrabbed = component.GrabStage != GrabStage.No;
     }
 
-    private void OnGrabAttempt(Entity<GrabbableComponent> ent, ref GrabAttemptEvent args) // Arcane - хардграб ксеноморфам
+    // Arcane-Start: Xeno instant hardgrab support
+    private void OnGrabAttempt(Entity<GrabbableComponent> ent, ref GrabAttemptEvent args)
     {
         if (!TryComp<PullableComponent>(ent, out var pullable))
             return;
 
-        var grabStageOverride = args.GrabStageOverride;
-        var isXenoInstant = false;
-        XenoInstantGrabComponent? xenoGrab = null;
+        // Arcane-Start
+        var grabStageOverride = TryGetXenoInstantOverride(args.Puller, out var xenoGrab)
+            ? GrabStage.Hard
+            : args.GrabStageOverride;
 
-        if (TryComp(args.Puller, out xenoGrab) && _timing.CurTime >= xenoGrab.NextInstantGrab)
-        {
-            grabStageOverride = GrabStage.Hard;
-            isXenoInstant = true;
-        }
-
-        var grabbed = TryGrab((ent.Owner, pullable, ent.Comp),
+        var grabbed = TryGrab((ent.Owner, pullable, ent.Comp), // Arcane-Edit
             args.Puller,
             args.IgnoreCombatMode,
-            grabStageOverride,
+            grabStageOverride, // Arcane-Edit
             args.EscapeAttemptModifier);
 
         args.Grabbed = grabbed;
 
-        // Кулдаун срабатывает только если TryGrab вернул true
-        if (grabbed && isXenoInstant && xenoGrab != null)
-        {
-            xenoGrab.NextInstantGrab = _timing.CurTime + xenoGrab.Cooldown;
-            Dirty(args.Puller, xenoGrab);
-        }
-    } // Arcane
+        if (grabbed && xenoGrab != null)
+            ApplyXenoInstantCooldown(args.Puller, xenoGrab);
+        // Arcane-End
+    }
+
+// Arcane: Checks if the puller has an off-cooldown instant hardgrab
+    private bool TryGetXenoInstantOverride(EntityUid puller, out XenoInstantGrabComponent? xenoGrab)
+    {
+        xenoGrab = null;
+
+        if (!TryComp(puller, out XenoInstantGrabComponent? comp) || _timing.CurTime < comp.NextInstantGrab)
+            return false;
+
+        xenoGrab = comp;
+        return true;
+    }
+
+// Arcane: Cooldown only applies if TryGrab succeeded
+    private void ApplyXenoInstantCooldown(EntityUid puller, XenoInstantGrabComponent xenoGrab)
+    {
+        xenoGrab.NextInstantGrab = _timing.CurTime + xenoGrab.Cooldown;
+        Dirty(puller, xenoGrab);
+    }
+    // Arcane-End
 
     private void OnPullableMoveInput(EntityUid uid, GrabbableComponent component, ref MoveInputEvent args)
     {

--- a/Content.Goobstation.Shared/Xenomorph/XenoInstantGrabComponent.cs
+++ b/Content.Goobstation.Shared/Xenomorph/XenoInstantGrabComponent.cs
@@ -3,12 +3,12 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Goobstation.Shared.Xenomorph;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class XenoInstantGrabComponent : Component
 {
     [DataField("cooldown")]
     public TimeSpan Cooldown = TimeSpan.FromSeconds(5);
 
-    [DataField("nextInstantGrab", customTypeSerializer: typeof(TimeOffsetSerializer))]
-    public TimeSpan NextInstantGrab = TimeSpan.Zero;
+    [DataField("nextInstantGrab", customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    public TimeSpan NextInstantGrab { get; set; } = TimeSpan.Zero;
 }

--- a/Content.Goobstation.Shared/Xenomorph/XenoInstantGrabComponent.cs
+++ b/Content.Goobstation.Shared/Xenomorph/XenoInstantGrabComponent.cs
@@ -1,0 +1,14 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Goobstation.Shared.Xenomorph;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class XenoInstantGrabComponent : Component
+{
+    [DataField("cooldown")]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(5);
+
+    [DataField("nextInstantGrab", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan NextInstantGrab = TimeSpan.Zero;
+}

--- a/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -24,20 +24,11 @@ public sealed partial class XenomorphsRuleComponent : Component
     public string? Announcement = "xenomorphs-announcement";
 
     [DataField] // Goobstation - play music on announcement
-    public SoundSpecifier XenomorphInfestationSound =
-            new SoundPathSpecifier("/Audio/_Goobstation/Music/Black_Swarm_Short.ogg")
-            {
-                Params = AudioParams.Default
-                    .WithVolume(-8f)
-            };
+    public SoundSpecifier? XenomorphInfestationSound;
 
     [DataField] // Goobstation - play music on announcement
-    public SoundSpecifier XenomorphTakeoverSound =
-            new SoundPathSpecifier("/Audio/_Goobstation/Music/Colonial_Marines_The_Final_Battle.ogg")
-            {
-                Params = AudioParams.Default
-                    .WithVolume(-8f)
-            };
+    public SoundSpecifier? XenomorphTakeoverSound;
+
 
     [DataField]
     public Color AnnouncementColor = Color.Red;

--- a/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Audio;
 
 namespace Content.Server._White.GameTicking.Rules.Components;
@@ -20,12 +21,11 @@ public sealed partial class XenomorphsRuleComponent : Component
 
     #region Announcement
 
-    [DataField]
-    public string? Announcement = "xenomorphs-announcement";
+    [DataField("announcement")]
+    public string? Announcement { get; set; } = null; // убрал оповещение - Arcane
 
-    [DataField] // Goobstation - play music on announcement
-    public SoundSpecifier? XenomorphInfestationSound; // Arcane - убрал музыку и оповощение ксено
-
+    [DataField("xenomorphInfestationSound")] // Goobstation - play music on announcement
+    public SoundSpecifier? XenomorphInfestationSound { get; set; } = null; // Arcane - убрал музыку
     [DataField] // Goobstation - play music on announcement
     public SoundSpecifier XenomorphTakeoverSound =
         new SoundPathSpecifier("/Audio/_Goobstation/Music/Colonial_Marines_The_Final_Battle.ogg")
@@ -48,10 +48,10 @@ public sealed partial class XenomorphsRuleComponent : Component
     public string? Sender;
 
     [DataField]
-    public TimeSpan MinTimeToAnnouncement = TimeSpan.FromSeconds(400);
+    public TimeSpan MinTimeToAnnouncement = TimeSpan.FromSeconds(450);
 
     [DataField]
-    public TimeSpan MaxTimeToAnnouncement = TimeSpan.FromSeconds(450);
+    public TimeSpan MaxTimeToAnnouncement = TimeSpan.FromSeconds(600);
 
     [ViewVariables]
     public bool Announced;

--- a/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -24,10 +24,10 @@ public sealed partial class XenomorphsRuleComponent : Component
     public string? Announcement = "xenomorphs-announcement";
 
     [DataField] // Goobstation - play music on announcement
-    public SoundSpecifier? XenomorphInfestationSound;
+    public SoundSpecifier? XenomorphInfestationSound; // Arcane - убрал музыку и оповощение ксено
 
     [DataField] // Goobstation - play music on announcement
-    public SoundSpecifier? XenomorphTakeoverSound;
+    public SoundSpecifier? XenomorphTakeoverSound; // Arcane - убрал музыку и оповощение ксено
 
 
     [DataField]

--- a/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -22,10 +22,10 @@ public sealed partial class XenomorphsRuleComponent : Component
     #region Announcement
 
     [DataField("announcement")]
-    public string? Announcement { get; set; } = null; // убрал оповещение - Arcane
+    public string? Announcement { get; set; } = null; // Arcane: removed announcement
 
     [DataField("xenomorphInfestationSound")] // Goobstation - play music on announcement
-    public SoundSpecifier? XenomorphInfestationSound { get; set; } = null; // Arcane - убрал музыку
+    public SoundSpecifier? XenomorphInfestationSound { get; set; } = null; // Arcane: removed music on announcement
     [DataField] // Goobstation - play music on announcement
     public SoundSpecifier XenomorphTakeoverSound =
         new SoundPathSpecifier("/Audio/_Goobstation/Music/Colonial_Marines_The_Final_Battle.ogg")

--- a/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Server/_White/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -27,7 +27,12 @@ public sealed partial class XenomorphsRuleComponent : Component
     public SoundSpecifier? XenomorphInfestationSound; // Arcane - убрал музыку и оповощение ксено
 
     [DataField] // Goobstation - play music on announcement
-    public SoundSpecifier? XenomorphTakeoverSound; // Arcane - убрал музыку и оповощение ксено
+    public SoundSpecifier XenomorphTakeoverSound =
+        new SoundPathSpecifier("/Audio/_Goobstation/Music/Colonial_Marines_The_Final_Battle.ogg")
+        {
+            Params = AudioParams.Default
+                .WithVolume(-8f)
+        };
 
 
     [DataField]

--- a/Content.Server/_White/GameTicking/Rules/XenomorphsRuleSystem.cs
+++ b/Content.Server/_White/GameTicking/Rules/XenomorphsRuleSystem.cs
@@ -248,8 +248,8 @@ public sealed class XenomorphsRuleSystem : GameRuleSystem<XenomorphsRuleComponen
             if (!string.IsNullOrEmpty(component.Announcement))
                 _chat.DispatchGlobalAnnouncement(Loc.GetString(component.Announcement), component.Sender != null ? Loc.GetString(component.Sender) : null, colorOverride: component.AnnouncementColor);
 
-            if (component.XenomorphInfestationSound != null)
-                _audioSystem.PlayGlobal(component.XenomorphInfestationSound, Filter.Broadcast(), true); // Arcane - убрал оповещение и музыку ксеноморфов
+            if (component.XenomorphInfestationSound != null) // Arcane: removed xenomorph music and announcement
+                _audioSystem.PlayGlobal(component.XenomorphInfestationSound, Filter.Broadcast(), true);
         }
 
         CheckRoundEnd(uid, component, gameRule);

--- a/Content.Server/_White/GameTicking/Rules/XenomorphsRuleSystem.cs
+++ b/Content.Server/_White/GameTicking/Rules/XenomorphsRuleSystem.cs
@@ -248,7 +248,8 @@ public sealed class XenomorphsRuleSystem : GameRuleSystem<XenomorphsRuleComponen
             if (!string.IsNullOrEmpty(component.Announcement))
                 _chat.DispatchGlobalAnnouncement(Loc.GetString(component.Announcement), component.Sender != null ? Loc.GetString(component.Sender) : null, colorOverride: component.AnnouncementColor);
 
-            _audioSystem.PlayGlobal(component.XenomorphInfestationSound, Filter.Broadcast(), true); // Goobstation - Play music on announcement
+            if (component.XenomorphInfestationSound != null)
+                _audioSystem.PlayGlobal(component.XenomorphInfestationSound, Filter.Broadcast(), true); // Arcane - убрал оповещение и музыку ксеноморфов
         }
 
         CheckRoundEnd(uid, component, gameRule);

--- a/Content.Tests/Shared/XenoInstantGrabTest.cs
+++ b/Content.Tests/Shared/XenoInstantGrabTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Content.Goobstation.Shared.Xenomorph;
+using NUnit.Framework;
+
+namespace Content.Tests.Shared;
+
+[TestFixture]
+public sealed class XenoInstantGrabTest
+{
+    [Test]
+    public void XenoInstantGrabStateTest()
+    {
+        var comp = new XenoInstantGrabComponent
+        {
+            NextInstantGrab = TimeSpan.FromSeconds(10)
+        };
+
+        Assert.That(comp.NextInstantGrab, Is.EqualTo(TimeSpan.FromSeconds(10)));
+    }
+}

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -8,13 +8,13 @@
   - MobFlammable
   id: BaseMobXenomorph
   abstract: true
-  # Arcane
+  # ArcaneStart: added xenograb component
   components:
   - type: GrabIntent
   - type: Grabbable
   - type: XenoInstantGrab
     cooldown: 5
-  # Arcane
+  # ArcaneEnd
   - type: Xenomorph
     weedHeal: # Goobstation - nerfed healing
       groups:

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -8,7 +8,13 @@
   - MobFlammable
   id: BaseMobXenomorph
   abstract: true
+  # Arcane
   components:
+  - type: GrabIntent
+  - type: Grabbable
+  - type: XenoInstantGrab
+    cooldown: 5
+  # Arcane
   - type: Xenomorph
     weedHeal: # Goobstation - nerfed healing
       groups:

--- a/Resources/Prototypes/_White/GameRules/events.yml
+++ b/Resources/Prototypes/_White/GameRules/events.yml
@@ -21,9 +21,10 @@
     prototype: MobXenomorphLarva
   - type: XenomorphsRule
     announcement: null # Arcane - убрал оповещение о ксено
-    xenomorphInfestationSound:
-      collection: xeno_start #Goobstation
-      volume: -2
+    # xenomorphInfestationSound:
+    # collection: xeno_start #Goobstation
+    #  volume: -2
+    # ArcaneEnd
   - type: AntagObjectives
     objectives:
     - XenomorphSurviveObjective

--- a/Resources/Prototypes/_White/GameRules/events.yml
+++ b/Resources/Prototypes/_White/GameRules/events.yml
@@ -20,7 +20,8 @@
   - type: AntagSpawner
     prototype: MobXenomorphLarva
   - type: XenomorphsRule
-    announcement: null # Arcane - убрал оповещение о ксено
+    #ArcaneStart - removed announcement and music
+    announcement: null
     # xenomorphInfestationSound:
     # collection: xeno_start #Goobstation
     #  volume: -2

--- a/Resources/Prototypes/_White/GameRules/events.yml
+++ b/Resources/Prototypes/_White/GameRules/events.yml
@@ -20,6 +20,7 @@
   - type: AntagSpawner
     prototype: MobXenomorphLarva
   - type: XenomorphsRule
+    announcement: null # Arcane - убрал оповещение о ксено
     xenomorphInfestationSound:
       collection: xeno_start #Goobstation
       volume: -2
@@ -30,8 +31,8 @@
     agentName: xenomorph-round-end-agent-name
     definitions:
     - spawnerPrototype: SpawnPointGhostXenomorph
-      min: 1 # Orion-Edit: 2 > 1
-      max: 2 # Orion-Edit: 4 > 2
+      min: 2 # Orion-Edit: 2 > 1 # Arcane-Edit 1 > 2
+      max: 4 # Orion-Edit: 4 > 2 # Arcane-Edit 2 > 4
       pickPlayer: false
       briefing:
         text: xenomorph-role-greeting


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
Хардграб ксеноморфам с кд 5 секунд для эффективного отлова одиночных целей
Убрал первое оповещение о ксеноморфах с музыкой
Увеличил количество спавнящихся грудоломов (min 1>2, max2>4)
Должно сделать так, чтобы данные антагонисты не сосали 2v50 станции с красным кодом

## Медиа
<!-- Добавьте скриншоты/видео, для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте скриншоты, иначе он может быть закрыт. -->

https://github.com/user-attachments/assets/21d07b3a-350f-4528-9ed3-4ed251b69fb6



## Тип PR

- [X] Feature
- [X] Tweak

## Лицензионное соглашение
<!-- Согласие с CLA означает: Arcane SS14 Organization получает право использовать, модифицировать и распространять внесённые изменения в рамках условий лицензии -->
<!-- ⚠️ Отказ от лицензионного соглашения может повлечь за собой закрытие вашего PR ⚠️ -->

- [x] Я согласен с лицензионным соглашением Contributor License Agreement, для Arcane SS14 Organization.

**Изменения**
:cl: badjuju
- add: Добавил хардграб с кд 5 секунд ксеноморфам (как у партизанок)
- remove: Удалил оповещение и музыку о ксеноморфах, которое давалось спустя 6 минут их появления
- tweak: Увеличил количество спавнящихся грудоломов от рула: минимальное количество - 2, максимальное - 4 
